### PR TITLE
Fix brotli match when stream is nil

### DIFF
--- a/brotli.go
+++ b/brotli.go
@@ -28,14 +28,16 @@ func (br Brotli) Match(_ context.Context, filename string, stream io.Reader) (Ma
 		mr.ByName = true
 	}
 
-	// brotli does not have well-defined file headers or a magic number;
-	// the best way to match the stream is probably to try decoding part
-	// of it, but we'll just have to guess a large-enough size that is
-	// still small enough for the smallest streams we'll encounter
-	r := brotli.NewReader(stream)
-	buf := make([]byte, 16)
-	if _, err := io.ReadFull(r, buf); err == nil {
-		mr.ByStream = true
+	if stream != nil {
+		// brotli does not have well-defined file headers or a magic number;
+		// the best way to match the stream is probably to try decoding part
+		// of it, but we'll just have to guess a large-enough size that is
+		// still small enough for the smallest streams we'll encounter
+		r := brotli.NewReader(stream)
+		buf := make([]byte, 16)
+		if _, err := io.ReadFull(r, buf); err == nil {
+			mr.ByStream = true
+		}
 	}
 
 	return mr, nil

--- a/formats_test.go
+++ b/formats_test.go
@@ -455,5 +455,12 @@ func TestIdentifyASCIIFileStartingWithX(t *testing.T) {
 	if !errors.Is(err, NoMatch) {
 		t.Errorf("Identify failed: %v", err)
 	}
+}
 
+func TestIdentifyStreamNil(t *testing.T) {
+	format, _, err := Identify(context.Background(), "test.tar.zst", nil)
+	checkErr(t, err, "identifying tar.zst")
+	if format.Extension() != ".tar.zst" {
+		t.Errorf("unexpected format found: expected=.tar.zst actual=%s", format.Extension())
+	}
 }


### PR DESCRIPTION
The documentation for the `Match` function says that setting passing `nil` to `stream` is allowed, however there's a NPE in Brotli's `Match` because it doesn't properly check if stream is specified or not.