### PR TITLE
Fix error closing files from Filesystem

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -467,7 +467,10 @@ func (f ArchiveFS) Open(name string) (fs.File, error) {
 			return err
 		}
 
-		fsFile = closeBoth{File: innerFile, c: archiveFile}
+		fsFile = innerFile
+		if archiveFile != nil {
+			fsFile = closeBoth{File: innerFile, c: archiveFile}
+		}
 
 		if decompressor != nil {
 			fsFile = closeBoth{fsFile, decompressor}


### PR DESCRIPTION
Fixes #17

The underlying issue for #17 was [a typed nil bug](https://go.dev/doc/faq#nil_error). A nil `*os.File` was being assigned to `closeBoth.c` which is an `io.Closer`. So [this non-nil check](https://github.com/mholt/archives/blob/bbb6eb95ca5c4119a43dc165b34601db05d9df59/fs.go#L1075) will always be true even when the original *os.File is nil.

The solution in this PR is only make `fsFile` a `closeBoth` when `archiveFile != nil`.