### PR TITLE
tar: mimic fakeroot behaviour

### DIFF
--- a/tar.go
+++ b/tar.go
@@ -26,6 +26,18 @@ type Tar struct {
 	// a file within an archive will be logged and the
 	// operation will continue on remaining files.
 	ContinueOnError bool
+
+	// User ID of the file owner
+	Uid int
+
+	// Group ID of the file owner
+	Gid int
+
+	// Username of the file owner
+	Uname string
+
+	// Group name of the file owner
+	Gname string
 }
 
 func (Tar) Extension() string { return ".tar" }
@@ -96,6 +108,18 @@ func (t Tar) writeFileToArchive(ctx context.Context, tw *tar.Writer, file FileIn
 	if t.NumericUIDGID {
 		hdr.Uname = ""
 		hdr.Gname = ""
+	}
+	if t.Uid != 0 {
+		hdr.Uid = t.Uid
+	}
+	if t.Gid != 0 {
+		hdr.Gid = t.Gid
+	}
+	if t.Uname != "" {
+		hdr.Uname = t.Uname
+	}
+	if t.Gname != "" {
+		hdr.Gname = t.Gname
 	}
 
 	if err := tw.WriteHeader(hdr); err != nil {


### PR DESCRIPTION
As the title suggests, hereby I add a Fakeroot flag in order to set Uid, Gid, Uname and Gname to `root`. This is very useful to mimic fakeroot behaviour. In my use case, I need something like this to avoid the usage of any fakeroot facility, just before archival operations. I'm using these edits for days and everything seems to work just fine.