### PR TITLE
fix: `zip.Insert` not saving permissions

### DIFF
--- a/zip.go
+++ b/zip.go
@@ -304,7 +304,7 @@ func (z Zip) Insert(ctx context.Context, into io.ReadWriteSeeker, files []FileIn
 			}
 		}
 
-		w, err := zu.Append(hdr.Name, szip.APPEND_MODE_OVERWRITE)
+		w, err := zu.AppendHeader(hdr, szip.APPEND_MODE_OVERWRITE)
 		if err != nil {
 			return fmt.Errorf("inserting file header: %d: %s: %w", idx, file.Name(), err)
 		}


### PR DESCRIPTION
just a simple change to fix permission bits not being saved on files being inserted into a zipfile. i'm using archives on a project of mine and noticed that all files being inserted have 0644 permissions, despite the files having 0755 perms. after a bit of digging, i found that the [Append](https://github.com/STARRY-S/zip/blob/v0.2.3/updater.go#L208) method being used does not save file permissions due to creating its own FileHeader. according to the docs for AppendHeader:

> Writer takes ownership of fh and may mutate its fields. The caller must not modify fh after calling CreateHeader. 

`hdr` is not being modified after calling AppendHeader, so this should really work just fine