### PR TITLE
fix: Use CopyN to handle growing file size

### DIFF
--- a/archives.go
+++ b/archives.go
@@ -241,7 +241,7 @@ func openAndCopyFile(file FileInfo, w io.Writer) error {
 	// When file is in use and size is being written to, creating the compressed
 	// file will fail with "archive/tar: write too long." Using CopyN gracefully
 	// handles this.
-	_, err = io.Copy(w, fileReader)
+	_, err = io.CopyN(w, fileReader, file.Size())
 	if err != nil && err != io.EOF {
 		return err
 	}

--- a/formats_test.go
+++ b/formats_test.go
@@ -464,3 +464,30 @@ func TestIdentifyStreamNil(t *testing.T) {
 		t.Errorf("unexpected format found: expected=.tar.zst actual=%s", format.Extension())
 	}
 }
+
+func TestArchiveGrowingFile(t *testing.T) {
+	tmpTxtFileName, tmpTxtFileInfo := newTmpTextFile(t, "Small file")
+	t.Cleanup(func() {
+		os.RemoveAll(tmpTxtFileName)
+	})
+
+	// Open the file and make it larger
+	tmpFile, err := os.OpenFile(tmpTxtFileName, os.O_WRONLY, 0644)
+	if err != nil {
+		t.Errorf("Failed to open temp file: %v", err)
+	}
+	t.Cleanup(func() {
+		tmpFile.Close()
+	})
+
+	err = os.WriteFile(tmpTxtFileName, []byte("Much longer and larger file size for the second write"), 0644)
+	if err != nil {
+		t.Errorf("Failed to write to temp file: %v", err)
+	}
+
+	// Archive but use the initial file info
+	bytesArchived := archive(t, Tar{}, tmpTxtFileName, tmpTxtFileInfo)
+	if len(bytesArchived) == 0 {
+		t.Errorf("Failed to archive file: %v", err)
+	}
+}


### PR DESCRIPTION
Was hitting an issue archiving a tar with a file that was growing. The comment in the code indicates that CopyN should have been used with the file info size. Not sure if there is some history here I am missing.

Added test case that reproduced the issue prior to making the fix.