### PR TITLE
refactor: make extension detection more robust

### DIFF
--- a/brotli.go
+++ b/brotli.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"strings"
 	"unicode/utf8"
 
 	"github.com/andybalholm/brotli"
+
+	"github.com/mholt/archives/internal"
 )
 
 func init() {
@@ -26,7 +27,7 @@ func (br Brotli) Match(ctx context.Context, filename string, stream io.Reader) (
 	var mr MatchResult
 
 	// match filename
-	if strings.Contains(strings.ToLower(filename), br.Extension()) {
+	if extensions.Contains(filename, br.Extension()) {
 		mr.ByName = true
 	}
 

--- a/bz2.go
+++ b/bz2.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"strings"
 
 	"github.com/dsnet/compress/bzip2"
+
+	"github.com/mholt/archives/internal"
 )
 
 func init() {
@@ -25,7 +26,7 @@ func (bz Bz2) Match(_ context.Context, filename string, stream io.Reader) (Match
 	var mr MatchResult
 
 	// match filename
-	if strings.Contains(strings.ToLower(filename), bz.Extension()) {
+	if extensions.Contains(filename, bz.Extension()) {
 		mr.ByName = true
 	}
 

--- a/gz.go
+++ b/gz.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"strings"
 
 	"github.com/klauspost/compress/gzip"
 	"github.com/klauspost/pgzip"
+
+	"github.com/mholt/archives/internal"
 )
 
 func init() {
@@ -37,7 +38,7 @@ func (gz Gz) Match(_ context.Context, filename string, stream io.Reader) (MatchR
 	var mr MatchResult
 
 	// match filename
-	if strings.Contains(strings.ToLower(filename), gz.Extension()) {
+	if extensions.Contains(filename, gz.Extension()) {
 		mr.ByName = true
 	}
 

--- a/internal/extensionutils.go
+++ b/internal/extensionutils.go
@@ -1,0 +1,18 @@
+package extensions
+
+import (
+	"slices"
+	"strings"
+)
+
+func EndsWith(path string, extension string) bool {
+	extensions := strings.Split(strings.ToLower(path), ".")
+	ext := strings.Trim(extension, ".")
+	return extensions[len(extensions)-1] == ext
+}
+
+func Contains(path string, extension string) bool {
+	extensions := strings.Split(strings.ToLower(path), ".")
+	ext := strings.Trim(extension, ".")
+	return slices.Contains(extensions, ext)
+}

--- a/internal/extensionutils_test.go
+++ b/internal/extensionutils_test.go
@@ -1,0 +1,53 @@
+package extensions
+
+import (
+	"testing"
+)
+
+func TestEndsWith(t *testing.T) {
+	for _, tc := range []struct {
+		input     string
+		extension string
+		want      bool
+	}{
+		{input: "test.tar", extension: "tar", want: true},
+		{input: "test.tar", extension: "gz", want: false},
+		{input: "test.tar.gz", extension: "tar", want: false},
+		{input: "test.tar.gz", extension: "gz", want: true},
+		{input: "test.tar.br", extension: "br", want: true},
+		{input: "test.tar.br", extension: "bru", want: false},
+	} {
+		t.Run(tc.input, func(t *testing.T) {
+			for _, ext := range []string{tc.extension, "." + tc.extension} {
+				got := EndsWith(tc.input, ext)
+				if got != tc.want {
+					t.Errorf("want: '%v', got: '%v')", tc.want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestContains(t *testing.T) {
+	for _, tc := range []struct {
+		input     string
+		extension string
+		want      bool
+	}{
+		{input: "test.tar", extension: "tar", want: true},
+		{input: "test.tar", extension: "gz", want: false},
+		{input: "test.tar.gz", extension: "tar", want: true},
+		{input: "test.tar.gz", extension: "gz", want: true},
+		{input: "test.tar.br", extension: "br", want: true},
+		{input: "test.tar.br", extension: "bru", want: false},
+	} {
+		t.Run(tc.input, func(t *testing.T) {
+			for _, ext := range []string{tc.extension, "." + tc.extension} {
+				got := Contains(tc.input, ext)
+				if got != tc.want {
+					t.Errorf("want: '%v', got: '%v')", tc.want, got)
+				}
+			}
+		})
+	}
+}

--- a/lz4.go
+++ b/lz4.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"strings"
 
 	"github.com/pierrec/lz4/v4"
+
+	"github.com/mholt/archives/internal"
 )
 
 func init() {
@@ -25,7 +26,7 @@ func (lz Lz4) Match(_ context.Context, filename string, stream io.Reader) (Match
 	var mr MatchResult
 
 	// match filename
-	if strings.Contains(strings.ToLower(filename), lz.Extension()) {
+	if extensions.Contains(filename, lz.Extension()) {
 		mr.ByName = true
 	}
 

--- a/lzip.go
+++ b/lzip.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"path/filepath"
-	"strings"
 
 	"github.com/sorairolake/lzip-go"
+
+	"github.com/mholt/archives/internal"
 )
 
 func init() {
@@ -24,7 +24,7 @@ func (lz Lzip) Match(_ context.Context, filename string, stream io.Reader) (Matc
 	var mr MatchResult
 
 	// match filename
-	if filepath.Ext(strings.ToLower(filename)) == lz.Extension() {
+	if extensions.EndsWith(filename, lz.Extension()) {
 		mr.ByName = true
 	}
 

--- a/minlz.go
+++ b/minlz.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"path/filepath"
-	"strings"
 
 	"github.com/minio/minlz"
+
+	"github.com/mholt/archives/internal"
 )
 
 func init() {
@@ -27,7 +27,7 @@ func (mz MinLZ) Match(_ context.Context, filename string, stream io.Reader) (Mat
 	var mr MatchResult
 
 	// match filename
-	if filepath.Ext(strings.ToLower(filename)) == ".mz" {
+	if extensions.Contains(filename, mz.Extension()) {
 		mr.ByName = true
 	}
 

--- a/rar.go
+++ b/rar.go
@@ -10,10 +10,11 @@ import (
 	"log"
 	"os"
 	"path"
-	"strings"
 	"time"
 
 	"github.com/nwaples/rardecode/v2"
+
+	"github.com/mholt/archives/internal"
 )
 
 func init() {
@@ -60,7 +61,7 @@ func (r Rar) Match(_ context.Context, filename string, stream io.Reader) (MatchR
 	var mr MatchResult
 
 	// match filename
-	if strings.Contains(strings.ToLower(filename), r.Extension()) {
+	if extensions.Contains(filename, r.Extension()) {
 		mr.ByName = true
 	}
 

--- a/sz.go
+++ b/sz.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"strings"
 
 	"github.com/klauspost/compress/s2"
+
+	"github.com/mholt/archives/internal"
 )
 
 func init() {
@@ -51,8 +52,8 @@ func (sz Sz) Match(_ context.Context, filename string, stream io.Reader) (MatchR
 	var mr MatchResult
 
 	// match filename
-	if strings.Contains(strings.ToLower(filename), sz.Extension()) ||
-		strings.Contains(strings.ToLower(filename), ".s2") {
+	if extensions.Contains(filename, sz.Extension()) ||
+		extensions.Contains(filename, ".s2") {
 		mr.ByName = true
 	}
 

--- a/tar.go
+++ b/tar.go
@@ -8,7 +8,8 @@ import (
 	"io"
 	"io/fs"
 	"log"
-	"strings"
+
+	"github.com/mholt/archives/internal"
 )
 
 func init() {
@@ -47,7 +48,7 @@ func (t Tar) Match(_ context.Context, filename string, stream io.Reader) (MatchR
 	var mr MatchResult
 
 	// match filename
-	if strings.Contains(strings.ToLower(filename), t.Extension()) {
+	if extensions.Contains(filename, t.Extension()) {
 		mr.ByName = true
 	}
 

--- a/xz.go
+++ b/xz.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"strings"
 
 	fastxz "github.com/mikelolasagasti/xz"
 	"github.com/ulikunitz/xz"
+
+	"github.com/mholt/archives/internal"
 )
 
 func init() {
@@ -24,7 +25,7 @@ func (x Xz) Match(_ context.Context, filename string, stream io.Reader) (MatchRe
 	var mr MatchResult
 
 	// match filename
-	if strings.Contains(strings.ToLower(filename), x.Extension()) {
+	if extensions.Contains(filename, x.Extension()) {
 		mr.ByName = true
 	}
 

--- a/zip.go
+++ b/zip.go
@@ -19,6 +19,8 @@ import (
 	"github.com/klauspost/compress/zip"
 	"github.com/klauspost/compress/zstd"
 	"github.com/ulikunitz/xz"
+
+	"github.com/mholt/archives/internal"
 )
 
 func init() {
@@ -85,7 +87,7 @@ func (z Zip) Match(_ context.Context, filename string, stream io.Reader) (MatchR
 	var mr MatchResult
 
 	// match filename
-	if strings.Contains(strings.ToLower(filename), z.Extension()) {
+	if extensions.Contains(filename, z.Extension()) {
 		mr.ByName = true
 	}
 

--- a/zlib.go
+++ b/zlib.go
@@ -3,9 +3,10 @@ package archives
 import (
 	"context"
 	"io"
-	"strings"
 
 	"github.com/klauspost/compress/zlib"
+
+	"github.com/mholt/archives/internal"
 )
 
 func init() {
@@ -24,7 +25,7 @@ func (zz Zlib) Match(_ context.Context, filename string, stream io.Reader) (Matc
 	var mr MatchResult
 
 	// match filename
-	if strings.Contains(strings.ToLower(filename), zz.Extension()) {
+	if extensions.Contains(filename, zz.Extension()) {
 		mr.ByName = true
 	}
 

--- a/zstd.go
+++ b/zstd.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"strings"
 
 	"github.com/klauspost/compress/zstd"
+
+	"github.com/mholt/archives/internal"
 )
 
 func init() {
@@ -26,7 +27,7 @@ func (zs Zstd) Match(_ context.Context, filename string, stream io.Reader) (Matc
 	var mr MatchResult
 
 	// match filename
-	if strings.Contains(strings.ToLower(filename), zs.Extension()) {
+	if extensions.Contains(filename, zs.Extension()) {
 		mr.ByName = true
 	}
 


### PR DESCRIPTION
Current extension detection relies on string search which can lead to situation where a normal file is seen as an archive such as with the brotli extension which is br and the Bru markup language which uses bru.

This refactor implement the detection based on splitting the file name on dots and then check the artifacts base on that. While not bullet proof it should keep the current behaviour while avoiding situation where close extension gets mixed.

Fixes https://github.com/gitleaks/gitleaks/issues/1949