### PR TITLE
Remove unused WriterTo interface constraint from rarReader type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707
 	github.com/klauspost/compress v1.18.0
 	github.com/klauspost/pgzip v1.2.6
-	github.com/nwaples/rardecode/v2 v2.1.1
+	github.com/nwaples/rardecode/v2 v2.2.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/mikelolasagasti/xz v1.0.1 h1:Q2F2jX0RYJUG3+WsM+FJknv+6eVjsjXNDV0KJXZz
 github.com/mikelolasagasti/xz v1.0.1/go.mod h1:muAirjiOUxPRXwm9HdDtB3uoRPrGnL85XHtokL9Hcgc=
 github.com/minio/minlz v1.0.1 h1:OUZUzXcib8diiX+JYxyRLIdomyZYzHct6EShOKtQY2A=
 github.com/minio/minlz v1.0.1/go.mod h1:qT0aEB35q79LLornSzeDH75LBf3aH1MV+jB5w9Wasec=
-github.com/nwaples/rardecode/v2 v2.1.1 h1:OJaYalXdliBUXPmC8CZGQ7oZDxzX1/5mQmgn0/GASew=
-github.com/nwaples/rardecode/v2 v2.1.1/go.mod h1:7uz379lSxPe6j9nvzxUZ+n7mnJNgjsRNb6IbvGVHRmw=
+github.com/nwaples/rardecode/v2 v2.2.0 h1:4ufPGHiNe1rYJxYfehALLjup4Ls3ck42CWwjKiOqu0A=
+github.com/nwaples/rardecode/v2 v2.2.0/go.mod h1:7uz379lSxPe6j9nvzxUZ+n7mnJNgjsRNb6IbvGVHRmw=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/rar.go
+++ b/rar.go
@@ -23,7 +23,6 @@ func init() {
 type rarReader interface {
 	Next() (*rardecode.FileHeader, error)
 	io.Reader
-	io.WriterTo
 }
 
 type Rar struct {


### PR DESCRIPTION
## Issue

  The `rardecode` v2.2.0 library removed the `WriterTo` method from its `Reader` and `ReadCloser` types, causing
  compilation failures:

```
go test ./...
# github.com/mholt/archives [github.com/mholt/archives.test]
./rar.go:105:9: cannot use or (variable of type *rardecode.ReadCloser) as rarReader value in assignment: *rardecode.ReadCloser does not implement rarReader (missing method WriteTo)
./rar.go:109:13: cannot use rardecode.NewReader(sourceArchive, options...) (value of type *rardecode.Reader) as rarReader value in assignment: *rardecode.Reader does not implement rarReader (missing method WriteTo)
FAIL	github.com/mholt/archives [build failed]
FAIL
```

  ## Solution

  Removed `io.WriterTo` from the `rarReader` interface definition since it was never actually used in the archives codebase.
  The interface now only requires `Next()` and `io.Reader`, which are the methods actually utilized by the RAR
  extraction implementation.

