### PR TITLE
fix: ArchiveFS.Sub mutated receiver and replaced prefix instead of joining

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -738,9 +738,9 @@ func (f *ArchiveFS) Sub(dir string) (fs.FS, error) {
 	// the reason we don't append to the Path field directly
 	// is because the input might be a stream rather than a
 	// path on disk, and the Prefix field is applied on both
-	result := f
-	result.Prefix = dir
-	return result, nil
+	result := *f
+	result.Prefix = path.Join(f.Prefix, dir)
+	return &result, nil
 }
 
 // DeepFS is a fs.FS that represents the real file system, but also has

--- a/fs_test.go
+++ b/fs_test.go
@@ -294,6 +294,50 @@ func TestArchiveFS_ReadDir(t *testing.T) {
 	}
 }
 
+func TestArchiveFS_Sub(t *testing.T) {
+	fsys := &ArchiveFS{
+		Stream: io.NewSectionReader(bytes.NewReader(unorderZip), 0, int64(len(unorderZip))),
+		Format: Zip{},
+	}
+
+	sub, err := fsys.Sub("2")
+	if err != nil {
+		t.Fatalf("Sub(%q): %v", "2", err)
+	}
+
+	// Sub must not mutate the receiver.
+	if fsys.Prefix != "" {
+		t.Errorf("Sub mutated receiver Prefix, got %q want %q", fsys.Prefix, "")
+	}
+
+	got, err := fs.ReadDir(sub, ".")
+	if err != nil {
+		t.Fatalf("ReadDir on sub: %v", err)
+	}
+	names := []string{}
+	for _, e := range got {
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+	if want := []string{"1"}; !reflect.DeepEqual(names, want) {
+		t.Errorf("ReadDir(sub, .) got %v want %v", names, want)
+	}
+
+	// The original FS must still see the full tree.
+	root, err := fs.ReadDir(fsys, ".")
+	if err != nil {
+		t.Fatalf("ReadDir on original: %v", err)
+	}
+	rootNames := []string{}
+	for _, e := range root {
+		rootNames = append(rootNames, e.Name())
+	}
+	sort.Strings(rootNames)
+	if want := []string{"1", "2"}; !reflect.DeepEqual(rootNames, want) {
+		t.Errorf("ReadDir(fsys, .) got %v want %v", rootNames, want)
+	}
+}
+
 func TestFileSystem(t *testing.T) {
 	ctx := context.Background()
 	filename := "testdata/test.zip"


### PR DESCRIPTION
ArchiveFS.Sub copied the receiver pointer rather than the struct, so it mutated the original FS, and it overwrote Prefix instead of joining onto any existing prefix, breaking nested Sub calls. This copies the struct and joins the prefix. Closes #67.