### PR TITLE
fs: make ArchiveFS.Sub return a new FS rooted at the joined prefix

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -737,10 +737,15 @@ func (f *ArchiveFS) Sub(dir string) (fs.FS, error) {
 	// we indicate a path prefix to be used for all operations;
 	// the reason we don't append to the Path field directly
 	// is because the input might be a stream rather than a
-	// path on disk, and the Prefix field is applied on both
-	result := f
-	result.Prefix = dir
-	return result, nil
+	// path on disk, and the Prefix field is applied on both.
+	//
+	// Take a shallow copy of f so we don't mutate the caller's
+	// ArchiveFS, and join dir onto any existing Prefix so a
+	// chained Sub(a).Sub(b) ends up rooted at a/b rather than
+	// replacing the original prefix.
+	result := *f
+	result.Prefix = path.Join(f.Prefix, dir)
+	return &result, nil
 }
 
 // DeepFS is a fs.FS that represents the real file system, but also has


### PR DESCRIPTION
Closes #67.

\`ArchiveFS.Sub\` was doing \`result := f\` (which copies the pointer, not the struct) and then overwriting \`Prefix\` in place. Two problems:

- the caller's own \`ArchiveFS\` got its \`Prefix\` silently rewritten under it
- chaining \`Sub(a).Sub(b)\` ended up rooted at \`b\` because the second call clobbered the first prefix instead of joining onto it

Take a shallow struct copy and use \`path.Join\` so the returned FS is rooted at the cumulative prefix. The original FS is left alone.