### PR TITLE
test: add regression for ArchiveFS.ReadDir on implicit ZIP dirs

### DIFF
--- a/fs_test.go
+++ b/fs_test.go
@@ -1,6 +1,7 @@
 package archives
 
 import (
+	"archive/zip"
 	"bytes"
 	"context"
 	_ "embed"
@@ -291,6 +292,61 @@ func TestArchiveFS_ReadDir(t *testing.T) {
 				})
 			}
 		})
+	}
+}
+
+// TestArchiveFS_ReadDir_ImplicitDirsZip guards against regression on #72:
+// ZIPs built without explicit directory entries (the default for `zip -r ...`
+// on most systems) must still expose parent directories through ReadDir.
+func TestArchiveFS_ReadDir_ImplicitDirsZip(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	for _, name := range []string{
+		"index.html",
+		"assets/1.txt",
+		"assets/2.txt",
+		"assets/more/3.txt",
+		"assets/four/4.txt",
+	} {
+		zw, err := w.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := zw.Write([]byte("x")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	fsys := ArchiveFS{
+		Stream: io.NewSectionReader(bytes.NewReader(buf.Bytes()), 0, int64(buf.Len())),
+		Format: Zip{},
+	}
+
+	want := map[string][]string{
+		".":           {"assets", "index.html"},
+		"assets":      {"1.txt", "2.txt", "four", "more"},
+		"assets/more": {"3.txt"},
+		"assets/four": {"4.txt"},
+	}
+	for dir, wantLS := range want {
+		entries, err := fsys.ReadDir(dir)
+		if err != nil {
+			t.Errorf("ReadDir(%q): %v", dir, err)
+			continue
+		}
+		got := []string{}
+		for _, e := range entries {
+			got = append(got, e.Name())
+		}
+		sort.Strings(got)
+		if !reflect.DeepEqual(got, wantLS) {
+			t.Errorf("ReadDir(%q) = %v, want %v", dir, got, wantLS)
+		}
 	}
 }
 


### PR DESCRIPTION
#72 reported \`ArchiveFS.ReadDir\` returning empty entries for parent directories on ZIPs without explicit directory entries (the default for \`zip -r\`). I tried to repro the bug against current \`main\` and it walks correctly through the implicit-dir fill in \`ReadDir()\`; the existing tests just don't cover that case.

Added an in-memory ZIP test that constructs the same shape the issue describes (file-only entries with nested paths) and asserts every parent shows up. Test passes today, so this only locks in current behaviour as a regression guard.

If a maintainer can confirm the bug really is gone, this should close out #72.

For #72